### PR TITLE
Integrate new animations more seamlessly with base game data structures

### DIFF
--- a/src/AnimationLoader.Koikatu/SwapAnim.cs
+++ b/src/AnimationLoader.Koikatu/SwapAnim.cs
@@ -45,7 +45,6 @@ namespace AnimationLoader.Koikatu
         
         private static Dictionary<EMode, List<SwapAnimationInfo>> animationDict;
         private static Dictionary<HSceneProc.AnimationListInfo, SwapAnimationInfo> swapAnimationMapping;
-        private static PositionCategory category;
         private static readonly Type vrType = Type.GetType("VRHScene, Assembly-CSharp");
         private static readonly Color buttonColor = new Color(0.96f, 1f, 0.9f);
 
@@ -85,8 +84,6 @@ namespace AnimationLoader.Koikatu
             if(vrType != null)
             {
                 harmony.Patch(AccessTools.Method(vrType, nameof(HSceneProc.ChangeAnimator)), postfix: new HarmonyMethod(typeof(SwapAnim), nameof(SwapAnimation)));
-                harmony.Patch(AccessTools.Method(vrType, nameof(HSceneProc.ChangeCategory)), prefix: new HarmonyMethod(typeof(SwapAnim), nameof(ChangeCategory)));
-                harmony.Patch(AccessTools.Method(vrType, nameof(HSceneProc.Start)), prefix: new HarmonyMethod(typeof(SwapAnim), nameof(InitCategory)));
                 harmony.Patch(AccessTools.Method(vrType, nameof(HSceneProc.CreateAllAnimationList)), postfix: new HarmonyMethod(typeof(SwapAnim), nameof(ExtendList)));
             }
         }
@@ -142,18 +139,6 @@ namespace AnimationLoader.Koikatu
                     list.Add(data);
                 }
             }
-        }
-
-        [HarmonyPrefix, HarmonyPatch(typeof(HSceneProc), nameof(HSceneProc.ChangeCategory))]
-        private static void ChangeCategory(int _category)
-        {
-            category = (PositionCategory)_category;
-        }
-
-        [HarmonyPostfix, HarmonyPatch(typeof(HSceneProc), nameof(HSceneProc.Start))]
-        private static void InitCategory(HSceneProc __instance, ref IEnumerator __result)
-        {
-            __result = __result.AppendCo(() => category = (PositionCategory)__instance.lstInitCategory.First());
         }
 
         [HarmonyPostfix, HarmonyPatch(typeof(HSceneProc), nameof(HSceneProc.CreateAllAnimationList))]

--- a/src/AnimationLoader.Koikatu/SwapAnimationInfo.cs
+++ b/src/AnimationLoader.Koikatu/SwapAnimationInfo.cs
@@ -10,6 +10,9 @@ namespace AnimationLoader.Koikatu
         [XmlIgnore]
         public string Guid;
 
+        [XmlIgnore]
+        public int Id = -1;
+
         [XmlElement]
         public int StudioId = -1;
         


### PR DESCRIPTION
This changes how new animations are integrated with the base game's data.  All original lists are fully made aware of the new animations by creating the new entries ahead of time and not tying them solely to the UI.  Sideloaded animations are identifiable by their dynamic id which is based against Sideloader Unique Slot Ids.  By extending the lstAnimInfo of HSceneProc, we also get to leverage koikatsu's list filtering logic, so no need to track category state in the plugin.

Motivation for this change came from a desire to be compatible with AnimationLoader without having an explicit dependency on it for an [AI mod I am implementing](https://github.com/nhydock/OpenKoikatsuPlugins#oktopme)