### PR TITLE
fix voices not loading

### DIFF
--- a/src/AnimationLoader.Koikatu/SwapAnimationInfo.cs
+++ b/src/AnimationLoader.Koikatu/SwapAnimationInfo.cs
@@ -10,9 +10,6 @@ namespace AnimationLoader.Koikatu
         [XmlIgnore]
         public string Guid;
 
-        [XmlIgnore]
-        public int Id = -1;
-
         [XmlElement]
         public int StudioId = -1;
         


### PR DESCRIPTION
undoes unique id change.  Koikatsu uses animation ids to load voice mappings from another file, so we can't have unique ones else the lookup breaks.  Without voices, animations also could not end properly

fixes #15 